### PR TITLE
fix: add undefined check before accessing author on commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const run = async () => {
     const reponame = payload.repository.full_name;
     const ref_path = payload.ref;
     const branchname = ref_path.split('/').pop();
-    const gitauthor = payload.commits[0]['author']['username'];
+    const gitauthor = payload.commits[0]?.['author']['username'];
     const head_commit_timestamp = Date.parse(payload.head_commit['timestamp']);
     const last_commit_epoch = parseInt(Math.round(head_commit_timestamp / 1000));
     const lead_time = (current_time - last_commit_epoch);


### PR DESCRIPTION
Appears that we have been getting this in the logs of the deployment github actions for `my-parsley`
```
(node:2845) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'author' of undefined
    at run (/home/runner/work/_actions/parsleyhealth/github-action-datadog/release/index.js:26:41)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:2845) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:2845) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

and [on the latest deploy, it terminated instead](https://github.com/parsleyhealth/my-parsley/actions/runs/5326048363/jobs/9652901035#step:3:7638).

This is to fix the TypeError.