### PR TITLE
Modified index.j' to handle If the ref_path variable is undefined or …

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,12 @@ const run = async () => {
 
     const payload = context.payload;
     const current_time = parseInt(Math.round((new Date()).getTime() / 1000));
-    const reponame = payload.repository.full_name;
+    const reponame = payload.repository?.full_name;
     const ref_path = payload.ref;
+    if (!ref_path) {
+        core.setFailed("Ref path is undefined or null.");
+        return;
+    }
     const branchname = ref_path.split('/').pop();
     const gitauthor = payload.commits[0]?.['author']['username'];
     const head_commit_timestamp = Date.parse(payload.head_commit['timestamp']);


### PR DESCRIPTION
…null, the code will set a failed status and return without attempting to split the variable.

This modification includes a null check for the ref_path variable and uses the optional chaining operator (?.) to securely access the payload.repository object's full_name property. If the ref_path variable is undefined or null, the code will return without attempting to divide the variable and set an error status.