### PR TITLE
Add conditional if to run staging and production. In the modified cod…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: ./
+      - name: Run custom action
+        uses: ./
         with:
-          datadog-api-key:  ${{ secrets.DATADOG_API_KEY_STAGING }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY_STAGING }}
           parsley-componentname: cicd
           parsley-environment: "staging"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_STAGING }}
+      - name: Run custom action (Production)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ./
+        with:
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY_PRODUCTION }}
+          parsley-componentname: cicd
+          parsley-environment: "production"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_PRODUCTION }}
+


### PR DESCRIPTION
…e, both steps will be present in the workflow, but only one of them will run depending on the environment.

In the modified code, both steps will be present in the workflow, but only one of them will run depending on the environment. The if expression is used to conditionally execute a step based on the value of github.ref.

In the code, the first step runs unconditionally, as it doesn't have an if condition specified. The second step, however, is conditionally executed using the if expression

The if expression checks if the github.ref starts with 'refs/tags/', indicating that it is a tag event. If the condition is true, the step will run, and if it is false, the step will be skipped.
This allows the workflow to have both staging and production configurations in a single workflow file, with the appropriate step being executed based on the event type.

@mst-ph @DuriDuri 
Although DataDog is going away, it still good to have this as we will reuse this when Coralogix step in.